### PR TITLE
Fix: prevent map handling in sidebar container

### DIFF
--- a/src/components/containers/SidebarViewsContainer.tsx
+++ b/src/components/containers/SidebarViewsContainer.tsx
@@ -1,16 +1,40 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 interface SidebarViewsContainerProps {
   children: ReactNode;
 }
 
-const SidebarViewsContainer: React.FC<SidebarViewsContainerProps> = ({
-  children,
-}) => {
-  if (!children) return null;
+const SidebarViewsContainer: React.FC<SidebarViewsContainerProps> = ({ children }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const stopProp = (e: Event) => e.stopPropagation()
+
+    const events = [
+      "mousemove",
+      "touchmove",
+      "wheel",
+      "dblclick",
+    ] as const;
+
+    for (const ev of events) {
+      container.addEventListener(ev, stopProp)
+    }
+    return () => {
+      for (const ev of events) {
+        container.removeEventListener(ev, stopProp)
+      }
+    }
+  }, [])
 
   return (
-    <div className="absolute z-[9999] bottom-0 left-0 md:top-0 md:left-0 w-full sm:w-fit h-fit">
+    <div
+      ref={containerRef}
+      className="absolute z-[9999] bottom-0 left-0 md:top-0 md:left-0 w-full sm:w-fit h-fit"
+    >
       {children}
     </div>
   );

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -17,7 +17,6 @@ import ViewWrapper from "@/components/sidebar/wrappers/ViewWrapper";
 import FlyToStop from "@/components/map/stop/FlyToStop";
 import Heading from "@/components/common/Heading";
 import SearchWrapper from "@/components/sidebar/search/SearchWrapper";
-import MapControlsContainer from "@/components/containers/MapControlsContainer";
 import SidebarViewsContainer from "@/components/containers/SidebarViewsContainer";
 import RoutePolyLineRenderer from "@/components/map/route/RoutePolyLineRenderer";
 import BusStopMarker from "@/components/map/markers/BusStopMarker";


### PR DESCRIPTION
## What I Fixed
Prevented unwanted map interaction when using the sidebar content area on pages with a map.

---

## The Problem
Since the `MapPagesLayout` wraps all pages with a map, user actions like scrolling or zooming inside components rendered by `SidebarViewsContainer` (e.g., search panels, results) were unintentionally propagating to the map.

This caused the map to respond (e.g., zoom or move) when interacting with sidebar content.

---

## The Solution
Added a `ref` to the main  `div` in `SidebarViewsContainer`, and used `useEffect` to:

- Attach `stopPropagation()` for events like:
  - `mousemove`
  - `touchmove`
  - `wheel`
  - `dblclick`

This prevents those events from bubbling up to the map layer behind it.

Now, interacting with the sidebar’s dynamic content no longer affects the map.